### PR TITLE
A spelling mistake causes the failure of setup_db.py

### DIFF
--- a/open-hackathon-server/src/hackathon/hmongo/models.py
+++ b/open-hackathon-server/src/hackathon/hmongo/models.py
@@ -120,7 +120,7 @@ class User(HDocumentBase):
             {
                 # default unqiue is not sparse, so we have to set it by ourselves
                 "fields": ["provider", "openid"],
-                "unqiue": True,
+                "unique": True,
                 "sparse": True}]}
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
In models.py, "unique" is spelled as "unqiue" by mistake, then
the db couldn't work well until it's fixed.

Signed-off-by: song chen <chensong@linuxep.com>