### PR TITLE
Fill in virtual_environment.para for guacamole

### DIFF
--- a/open-hackathon-server/src/hackathon/template/template_constants.py
+++ b/open-hackathon-server/src/hackathon/template/template_constants.py
@@ -189,6 +189,16 @@ class K8S_UNIT:
     REMOTE_PASSWORD = 'password'
     REMOTE_PORT = 'port'
 
+
+    # remote parameter name
+    REMOTE_PARAMETER_NAME = 'name'
+    REMOTE_PARAMETER_DISPLAY_NAME = 'displayname'
+    REMOTE_PARAMETER_HOST_NAME = 'hostname'
+    REMOTE_PARAMETER_PROTOCOL = 'protocol'
+    REMOTE_PARAMETER_PORT = 'port'
+    REMOTE_PARAMETER_USER_NAME = 'username'
+    REMOTE_PARAMETER_PASSWORD = 'password'
+
     IMAGES = 'images'
     IMAGES_IMAGE = 'image'
 


### PR DESCRIPTION
1, fill in ve.para after ve created successfully

Signed-off-by: chensong <chensong@linuxep.com>

ip should be hard coded later
username is user id in context
port is from k8s_dict,  so are display name and name
protocol is vnc
pwd, no idea, leave it empty