### PR TITLE
Integrate guacamole and guacd in the docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ docs/_build/
 *.cer
 *.pem
 
-*guacamole.properties
+#*guacamole.properties
 *config.py
 *.rb~
 *.erb~

--- a/deploy/guacamole/Dockerfile
+++ b/deploy/guacamole/Dockerfile
@@ -8,11 +8,12 @@
 
 FROM guacamole/guacamole:0.9.14
 
+USER root
+
 ENV GUACAMOLE_HOME /etc/guacamole
 
 RUN mkdir -p /usr/local/tomcat/.guacamole
 RUN mkdir -p /etc/guacamole/extensions
-COPY guacamole-sample.properties /etc/guacamole/guacamole.properties
-COPY *.jar /etc/guacamole/extensions/
+ADD ./deploy/guacamole/ *.jar /etc/guacamole/extensions/
 RUN ln -s /etc/guacamole/guacamole.properties /usr/local/tomcat/.guacamole/guacamole.properties
 

--- a/deploy/guacamole/properties/guacamole.properties
+++ b/deploy/guacamole/properties/guacamole.properties
@@ -1,0 +1,26 @@
+
+#    Guacamole - Clientless Remote Desktop
+#    Copyright (C) 2010  Michael Jumper
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Modifications Copyright (c) 2015 Microsoft  
+#
+
+# Hostname and port of guacamole proxy
+guacd-hostname: localhost
+guacd-port:     4822
+
+# Open Hackathon auth url
+auth-request-url: http://localhost:15000/api/user/guacamoleconfig

--- a/deploy/hackathon-docker/docker-compose.yml
+++ b/deploy/hackathon-docker/docker-compose.yml
@@ -26,11 +26,11 @@ services:
     environment:
       - DB_SERVER=db
       - DB_PORT=27017
-#     - GUACAMOLE=guacamole
-#     - GUACAMOLE_PORT=8080
+      - GUACAMOLE=guacamole
+      - GUACAMOLE_PORT=8080
     links:
       - 'db'
-#      - 'guacamole'
+      - 'guacamole'
     volumes:
       - "./logs/server:/var/log/open-hackathon"
     container_name: "kaiyuanshe-hackathon-server"
@@ -43,19 +43,23 @@ services:
      - "./db:/data/db"
     container_name: "kaiyuanshe-mongo"
 
-#  guacamole:
-#    image: "kaiyuanshe/guacamole:latest"
-#    build:
-#      context: ../../
-#      dockerfile: deploy/guacamole/Dockerfile
-#    ports:
-#      - "8080:8080"
-#    links:
-#      - "guacd"
-#    container_name: "kaiyuanshe-guacamole"
+  guacamole:
+    image: "kaiyuanshe/guacamole:latest"
+    build:
+      context: ../../
+      dockerfile: deploy/guacamole/Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - "./../guacamole/properties:/etc/guacamole"
+    environment:
+      - GUACD_HOSTNAME=guacd
+    links:
+      - "guacd"
+    container_name: "kaiyuanshe-guacamole-guacamole"
 
-#  guacd:
-#    image: "guacamole:guacd"
-#    ports:
-#     - "4822:4822"
-#    container_name: "kaiyuanshe-guacd"  
+  guacd:
+    image: "guacamole/guacd"
+    ports:
+     - "4822:4822"
+    container_name: "kaiyuanshe-guacamole-guacd"  

--- a/open-hackathon-server/src/hackathon/config_docker.py
+++ b/open-hackathon-server/src/hackathon/config_docker.py
@@ -32,8 +32,7 @@ Config = {
         "cert_base": "",
     },
     "guacamole": {
-        "host": "http://localhost:8080"
-        #"host": "http://" + os.environ["GUACAMOLE"] + ":" + int(os.environ[GUACAMOLE_PORT])
+        "host": "http://" + os.environ["GUACAMOLE"] + ":" + os.environ["GUACAMOLE_PORT"]
 
     },
     "scheduler": {


### PR DESCRIPTION
1, Add guacamole and guacd in docker-compose.yml
2, adapt docker-compose in guacamole Dockerfile
3, adapt guacamole env in config_docker.py

Signed-off-by: song chen <chensong@linuxep.com>

===============
it works with seeing 
"2019-06-23 03:25:41,393 - DEBUG(MainThread) - guacamole status: {'status': 'ok'}"

but there is something i haven't figured out yet:
1, mongo must be working at 27017, remap to 15100 e.g,failed.
2,guacamole must be working at 8080, remap to 15200 e.g, failed.
3, guacamole log 
"03:25:36.776 [localhost-startStop-1] ERROR o.a.g.extension.ExtensionModule - Extension "json-20090211.jar" could not be loaded: Extension json-20090211.jar is missing guac-manifest.json"
need junbo help to fix it.
4, pv if deploying hackathon in k8s, need hypo to config

